### PR TITLE
Remove apt cache to reduce image sizes

### DIFF
--- a/indigo/release/Dockerfile
+++ b/indigo/release/Dockerfile
@@ -4,8 +4,8 @@
 FROM osrf/ros:indigo-desktop
 MAINTAINER Dave Coleman dave@dav.ee
 
-RUN apt-get update && \
-    apt-get upgrade -y
-
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y ros-indigo-moveit-* \
+ && rm -rf /var/lib/apt/lists/*
 #TODO RUN apt-get install -y ros-indigo-moveit-full
-RUN apt-get install -y ros-indigo-moveit-*

--- a/jade/release/Dockerfile
+++ b/jade/release/Dockerfile
@@ -4,8 +4,8 @@
 FROM osrf/ros:jade-desktop
 MAINTAINER Dave Coleman dave@dav.ee
 
-RUN apt-get update && \
-    apt-get upgrade -y
-
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y ros-jade-moveit-* \
+ && rm -rf /var/lib/apt/lists/*
 #TODO RUN apt-get install -y ros-jade-moveit-full
-RUN apt-get install -y ros-jade-moveit-*

--- a/kinetic/release/Dockerfile
+++ b/kinetic/release/Dockerfile
@@ -4,8 +4,8 @@
 FROM osrf/ros:kinetic-desktop
 MAINTAINER Dave Coleman dave@dav.ee
 
-RUN apt-get update && \
-    apt-get upgrade -y
-
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y ros-kinetic-moveit-* \
+ && rm -rf /var/lib/apt/lists/*
 #TODO RUN apt-get install -y ros-kinetic-moveit-full
-RUN apt-get install -y ros-kinetic-moveit-*


### PR DESCRIPTION
If you run all apt commands in a single `RUN` statement and remove the apt files, it reduces the image sizes.

Here's an example from the ros docker files:
- https://github.com/osrf/docker_images/blob/master/ros/indigo/indigo-desktop-full/Dockerfile
